### PR TITLE
feat: tạo thống kê hằng ngày cho admin

### DIFF
--- a/BackEnd/app/Http/Controllers/StatisticsController.php
+++ b/BackEnd/app/Http/Controllers/StatisticsController.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\Statistic;
+
+class StatisticsController extends Controller
+{
+    public function getStatistics(Request $request)
+    {
+        $startDate = $request->query('start_date');
+        $endDate = $request->query('end_date');
+
+        $statistics = Statistic::whereBetween('date', [$startDate, $endDate])->get();
+
+        // Prepare the response data
+        $labels = [];
+        $sales = [];
+        $orders = [];
+        $users = [];
+
+        foreach ($statistics as $stat) {
+            $labels[] = $stat->date;
+            $sales[] = $stat->total_sales;
+            $orders[] = $stat->total_orders;
+            $users[] = $stat->total_users;
+        }
+
+        return response()->json([
+            'labels' => $labels,
+            'sales' => $sales,
+            'orders' => $orders,
+            'users' => $users,
+        ]);
+    }
+}

--- a/BackEnd/routes/api.php
+++ b/BackEnd/routes/api.php
@@ -14,6 +14,7 @@ use App\Http\Controllers\OrderController;
 use App\Http\Controllers\OrderItemController;
 use App\Mail\OrderConfirmationMail;
 use Illuminate\Support\Facades\Mail;
+use App\Http\Controllers\StatisticsController;
 
 // Lấy thông tin user hiện tại sau khi đã xác thực
 Route::get('/user', function (Request $request) {
@@ -70,3 +71,6 @@ Route::post('/users/{id}/verify-password', [UserController::class, 'verifyPasswo
 Route::post('/send-order-confirmation', [OrderController::class, 'sendOrderConfirmation']);
 
 Route::post('/google-login', [UserController::class, 'googleLogin']);
+
+//Lấy dữ liệu thống kê
+Route::get('/statistics', [StatisticsController::class, 'getStatistics']);

--- a/FrontEnd/package-lock.json
+++ b/FrontEnd/package-lock.json
@@ -9,8 +9,10 @@
       "version": "0.0.0",
       "dependencies": {
         "axios": "^1.7.2",
+        "chart.js": "^4.4.4",
         "firebase": "^10.13.0",
         "react": "^18.3.1",
+        "react-chartjs-2": "^5.2.0",
         "react-dom": "^18.3.1",
         "react-google-button": "^0.8.0",
         "react-hook-form": "^7.52.2",
@@ -1498,6 +1500,11 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.2.tgz",
+      "integrity": "sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw=="
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2344,6 +2351,17 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.4.tgz",
+      "integrity": "sha512-emICKGBABnxhMjUjlYRR12PmOXhJ2eJjEHL2/dZlWjxRAZT1D8xplLFq5M0tMQK8ja+wBS/tuVEJB5C6r7VxJA==",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/chokidar": {
@@ -5064,6 +5082,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-chartjs-2": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.2.0.tgz",
+      "integrity": "sha512-98iN5aguJyVSxp5U3CblRLH67J8gkfyGNbiK3c+l1QI/G4irHMPQw44aEPmjVag+YKTyQ260NcF82GTQ3bdscA==",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-dom": {

--- a/FrontEnd/package.json
+++ b/FrontEnd/package.json
@@ -12,7 +12,9 @@
   "dependencies": {
     "axios": "^1.7.2",
     "firebase": "^10.13.0",
+    "chart.js": "^4.4.4",
     "react": "^18.3.1",
+    "react-chartjs-2": "^5.2.0",
     "react-dom": "^18.3.1",
     "react-google-button": "^0.8.0",
     "react-hook-form": "^7.52.2",

--- a/FrontEnd/src/App.jsx
+++ b/FrontEnd/src/App.jsx
@@ -18,7 +18,7 @@ import SideBar from "./components/sharepages/SideBar.jsx";
 import { AuthProvider } from "./contexts/AuthContext.jsx";
 import Profile from "./components/pages/Profile.jsx";
 import AdminRoute from "./contexts/AdminRoute"; // Import từ cùng thư mục với AuthContext
-
+import StatisticsChart from './components/pages/admin/Chart.jsx';
 function App() {
   return (
     <Router>
@@ -60,7 +60,8 @@ function App() {
                   path="edit-product/:productId"
                   element={<UpdateProduct />}
                 />
-              </Route>
+                <Route path="statistics" element={<StatisticsChart />} />
+          </Route>
             </Routes>
             <Footer />
           </div>

--- a/FrontEnd/src/components/pages/admin/Chart.jsx
+++ b/FrontEnd/src/components/pages/admin/Chart.jsx
@@ -1,0 +1,106 @@
+import { useState, useEffect } from 'react';
+import { Line } from 'react-chartjs-2';
+import {
+    Chart as ChartJS,
+    CategoryScale,
+    LinearScale,
+    PointElement,
+    LineElement,
+    Title,
+    Tooltip,
+    Legend
+} from 'chart.js';
+import Axios from '../../../constants/Axios';
+
+ChartJS.register(
+    CategoryScale,
+    LinearScale,
+    PointElement,
+    LineElement,
+    Title,
+    Tooltip,
+    Legend
+);
+
+const Chart = () => {
+    const [chartData, setChartData] = useState({});
+
+    useEffect(() => {
+        const fetchData = async () => {
+            try {
+                const response = await Axios.get('/statistics', {
+                    params: {
+                        start_date: '2024-01-01', 
+                        end_date: '2024-12-31'  
+                    }
+                });
+                const data = response.data;
+
+                setChartData({
+                    labels: data.labels, // Dates
+                    datasets: [
+                        {
+                            label: 'Sales',
+                            data: data.sales, // Sales data
+                            backgroundColor: 'rgba(75,192,192,0.6)',
+                            borderColor: 'rgba(75,192,192,1)',
+                            borderWidth: 1,
+                        },
+                        {
+                            label: 'Orders',
+                            data: data.orders, // Orders data
+                            backgroundColor: 'rgba(153,102,255,0.6)',
+                            borderColor: 'rgba(153,102,255,1)',
+                            borderWidth: 1,
+                        },
+                        {
+                            label: 'Users',
+                            data: data.users, // Users data
+                            backgroundColor: 'rgba(255,159,64,0.6)',
+                            borderColor: 'rgba(255,159,64,1)',
+                            borderWidth: 1,
+                        }
+                    ],
+                });
+            } catch (error) {
+                console.error('Error fetching chart data', error);
+            }
+        };
+
+        fetchData();
+    }, []);
+
+    return (
+        <div className="p-20 bg-white shadow-lg rounded-lg">
+            <h2 className="text-3xl font-bold text-gray-800 mb-4">Sales, Orders, and Users Chart</h2>
+            <div className="relative">
+                {chartData.labels ? (
+                    <Line
+                        data={chartData}
+                        className="w-full h-full"
+                        options={{
+                            responsive: true,
+                            maintainAspectRatio: false,
+                            scales: {
+                                y: {
+                                    beginAtZero: true,
+                                },
+                            },
+                            plugins: {
+                                legend: {
+                                    labels: {
+                                        color: 'rgb(75, 85, 99)', 
+                                    },
+                                },
+                            },
+                        }}
+                    />
+                ) : (
+                    <p className="text-gray-500">Loading...</p>
+                )}
+            </div>
+        </div>
+    );
+};
+
+export default Chart;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "NAITEI-PHP-BATCH1-T6",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
- Thêm giao diện thống kê cho admin với biểu đồ
- Tạo API để cung cấp dữ liệu thống kê theo ngày
- Cấu hình cronjob để tự động tính toán và lưu trữ số liệu thống kê hàng ngày
- Cập nhật bảng  để lưu trữ số liệu thống kê